### PR TITLE
Updated group module to use new C_PartyInfo.GetLootMethod() API

### DIFF
--- a/Modules/Group/Group.lua
+++ b/Modules/Group/Group.lua
@@ -181,7 +181,7 @@ function addon:OnEnable()
 	end
 
 	-- Find and show active rolls
-	if IsInGroup() and (GetLootMethod() == 'group' or GetLootMethod() == 'needbeforegreed') then
+	if IsInGroup() and (C_PartyInfo.GetLootMethod() == 'group' or C_PartyInfo.GetLootMethod() == 'needbeforegreed') then
 		for i=1,300 do
 			local time = GetLootRollTimeLeft(i)
 			if time > 0 and time <  300000 then


### PR DESCRIPTION
Fix for 

> XLoot_Group/Group.lua:184: attempt to call global 'GetLootMethod' (a nil value)